### PR TITLE
Adaboost algorithm added

### DIFF
--- a/src/adaboost.py
+++ b/src/adaboost.py
@@ -65,7 +65,7 @@ class AdaBoostMain:
         plt.figure()
         plt.title("Feature importance for AdaBoost")
         plt.bar(range(data_train.shape[1]), feature_importances[indices],
-                color="y", align="center")
+                color="r", align="center")
 
         plt.xticks(range(data_train.shape[1]), data_train.columns[indices])
         plt.xlim([-1, data_train.shape[1]])

--- a/src/adaboost.py
+++ b/src/adaboost.py
@@ -1,12 +1,13 @@
 import pandas as pd
 from sklearn.model_selection import train_test_split
-from sklearn.tree import DecisionTreeClassifier
+from sklearn.ensemble import AdaBoostClassifier
 from sklearn.metrics import confusion_matrix, accuracy_score
 # Bar Chart
 import numpy as np
 import matplotlib.pyplot as plt
 
-class DecisionTreeMain:
+
+class AdaBoostMain:
     def __init__(self, phishing_csv_path, legitimate_csv_path):
         self.phishing_csv_path = phishing_csv_path
         self.legitimate_csv_path = legitimate_csv_path
@@ -38,13 +39,13 @@ class DecisionTreeMain:
         data_train, data_test, labels_train, labels_test = \
             train_test_split(urls_without_labels, labels, test_size=0.30, random_state=110)
 
-        print("Lengths of data trained and data tested in Decision Tree", len(data_train), len(data_test), len(labels_train), len(labels_test))
+        print("Lengths of data trained and data tested in AdaBoost", len(data_train), len(data_test), len(labels_train), len(labels_test))
 
         labels_train.value_counts()
         labels_test.value_counts()
 
         # creating the model and fitting the data into the model
-        model = DecisionTreeClassifier()
+        model = AdaBoostClassifier()
         model.fit(data_train, labels_train)
 
         # Predicting the results for test data
@@ -52,9 +53,9 @@ class DecisionTreeMain:
 
         # Creating confusion matrix and checking/printing the accuracy
         cm = confusion_matrix(labels_test, pred_label)
-        print("Decision Tree Confusion Matrix: ", cm)
+        print("AdaBoost Matrix: ", cm)
         accuracy = accuracy_score(labels_test, pred_label)
-        print("Decision Trees Accuracy: ", accuracy)
+        print("AdaBoost Accuracy: ", accuracy)
 
         #Print the bar chart
         feature_importances = model.feature_importances_
@@ -62,7 +63,7 @@ class DecisionTreeMain:
 
 
         plt.figure()
-        plt.title("Feature importance")
+        plt.title("Feature importance for AdaBoost")
         plt.bar(range(data_train.shape[1]), feature_importances[indices],
                 color="y", align="center")
 

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ from random_forest import RandomForestMain
 from decision_tree import DecisionTreeMain
 from logistic_reg import LogisticRegMain
 from naive_bayes import NaiveBayesMain
+from adaboost import AdaBoostMain
 import os
 
 os.makedirs('../extracted_csv_files/', exist_ok=True)
@@ -19,6 +20,7 @@ OUTPUT_PATH = '../extracted_csv_files/'
 # dt = DecisionTreeMain('../extracted_csv_files/phishing-urls.csv', '../extracted_csv_files/legitimate-urls.csv')
 # lr = LogisticRegMain('../extracted_csv_files/phishing-urls.csv', '../extracted_csv_files/legitimate-urls.csv')
 # nb = NaiveBayesMain('../extracted_csv_files/phishing-urls.csv', '../extracted_csv_files/legitimate-urls.csv')
+# ab = AdaBoostMain('../extracted_csv_files/phishing-urls.csv', '../extracted_csv_files/legitimate-urls.csv')
 
 # LONG WAY
 # run random forest on generated output files
@@ -35,8 +37,10 @@ rf = RandomForestMain(fe.output_phishing_file.name, fe.output_legitimate_file.na
 dt = DecisionTreeMain(fe.output_phishing_file.name, fe.output_legitimate_file.name)
 lr = LogisticRegMain(fe.output_phishing_file.name, fe.output_legitimate_file.name)
 nb = NaiveBayesMain(fe.output_phishing_file.name, fe.output_legitimate_file.name)
+ab = AdaBoostMain(fe.output_phishing_file.name, fe.output_legitimate_file.name)
 
 rf.main()
 dt.main()
 lr.main()
 nb.main()
+ab.main()


### PR DESCRIPTION
- Added[ Adaboost](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.AdaBoostClassifier.html) algorithm
- Graph was able to be made because it had `feature_importance_`
- Current output:
```
Random Forest Confusion Matrix:  [[735 171]
 [162 732]]
Random Forest Accuracy:  0.815
1 .  #Other word  :  0.0
2 .  #Similar brand  :  0.0
3 .  Brand check  :  0.0022731710858937544
4 .  #Subdomains  :  0.0039202242841860375
5 .  Short word len  :  0.0054107541209888034
6 .  #Raw word  :  0.011261002943073148
7 .  Random domain  :  0.02597996377448713
8 .  #Brand  :  0.02640756441113795
9 .  #Similar keyword  :  0.029614243730676414
10 .  #Keyword  :  0.033702122283226166
11 .  Avg word len  :  0.03782605136041299
12 .  Long word len  :  0.04490735550497253
13 .  URL len  :  0.05445595697168737
14 .  Path len  :  0.06277197788872325
15 .  #Random word  :  0.06968007320225131
16 .  Alexa  :  0.08114598640653657
17 .  Domain len  :  0.08351809866796157
18 .  Known TLD  :  0.10964603207027128
19 .  Subdomain len  :  0.3174794212935138
Lengths of data trained and data tested in Decision Tree 4200 1800 4200 1800
Decision Tree Confusion Matrix:  [[749 157]
 [217 677]]
Decision Trees Accuracy:  0.7922222222222223
Lengths of data trained and data tested 4200 1800 4200 1800
/usr/local/lib/python3.7/site-packages/sklearn/linear_model/logistic.py:433: FutureWarning: Default solver will be changed to 'lbfgs' in 0.22. Specify a solver to silence this warning.
  FutureWarning)
Logistic Regression Confusion Matrix:  [[685 216]
 [201 698]]
Logistic Regression Accuracy:  0.7683333333333333
Lengths of data trained and data tested in Gaussian Naive Bayes 4200 1800 4200 1800
Gaussian Naive Bayes Confusion Matrix:  [[673 248]
 [221 658]]
Gaussian Naive Bayes Accuracy:  0.7394444444444445
Lengths of data trained and data tested in AdaBoost 4200 1800 4200 1800
AdaBoost Matrix:  [[724 165]
 [190 721]]
AdaBoost Accuracy:  0.8027777777777778

Process finished with exit code 0
```
- Current graph outputs:
<img width="641" alt="screen shot 2019-03-02 at 8 16 14 pm" src="https://user-images.githubusercontent.com/9542958/53690944-195d2900-3d29-11e9-8fdd-d1435e097d5e.png">
<img width="656" alt="screen shot 2019-03-02 at 8 16 26 pm" src="https://user-images.githubusercontent.com/9542958/53690945-195d2900-3d29-11e9-837d-eb0a0675dd57.png">
<img width="644" alt="screen shot 2019-03-02 at 8 17 50 pm" src="https://user-images.githubusercontent.com/9542958/53690946-195d2900-3d29-11e9-9ae9-1cdd0f806d6d.png">


Fixes #13 